### PR TITLE
fix bug in setPropertyFlag

### DIFF
--- a/lib/player.dart
+++ b/lib/player.dart
@@ -199,7 +199,7 @@ class Player {
   }
 
   void setPropertyFlag(String name, bool value) {
-    final ptr = calloc<Bool>(1)..value = value;
+    final ptr = calloc<Int32>(1)..value = value ? 1 : 0;
     _setProperty(
       name,
       mpv_format.MPV_FORMAT_FLAG,

--- a/lib/player.dart
+++ b/lib/player.dart
@@ -294,7 +294,7 @@ class Player {
   }
 
   void setOptionFlag(String name, bool value) {
-    final ptr = calloc<Bool>(1)..value = value;
+    final ptr = calloc<Int32>(1)..value = value ? 1 : 0;
     setOptionAll(
       name,
       mpv_format.MPV_FORMAT_FLAG,


### PR DESCRIPTION
I found a bug in setPropertyFlag mpv expects a 4 byte flag but a 1 byte bool was passed.
https://github.com/mpv-player/mpv/blob/bd2118026b9b46da5633724b34e7849eec80f72c/include/mpv/client.h#L684-L699